### PR TITLE
Fixed issue where invalid headers in request broke connection

### DIFF
--- a/src/handler_forward.js
+++ b/src/handler_forward.js
@@ -32,6 +32,8 @@ export default class HandlerForward extends HandlerBase {
                 // will detect we're not a browser and also to improve performance
             } else if (isHopByHopHeader(headerName)) {
                 continue;
+            } else if (isInvalidHeader(headerName, headerValue)) {
+                continue;
             }
 
             /*


### PR DESCRIPTION
Requests sent through proxy chain with invalid headers caused the proxy chain to throw error and close connection. This skips the header instead.