### PR TITLE
Fix #32 - tunnel chain should set the target host in the 'host' heaer and not in the path parameter

### DIFF
--- a/src/handler_tunnel_chain.js
+++ b/src/handler_tunnel_chain.js
@@ -20,12 +20,16 @@ export default class HandlerTunnelChain extends HandlerBase {
     run() {
         this.log('Connecting to upstream proxy...');
 
+        const targetHost = `${this.trgParsed.hostname}:${this.trgParsed.port}`;
+
         const options = {
             method: 'CONNECT',
             hostname: this.upstreamProxyUrlParsed.hostname,
             port: this.upstreamProxyUrlParsed.port,
-            path: `${this.trgParsed.hostname}:${this.trgParsed.port}`,
-            headers: {},
+            path: targetHost,
+            headers: {
+                host: targetHost,
+            },
         };
 
         maybeAddProxyAuthorizationHeader(this.upstreamProxyUrlParsed, options.headers);

--- a/src/handler_tunnel_chain.js
+++ b/src/handler_tunnel_chain.js
@@ -28,7 +28,7 @@ export default class HandlerTunnelChain extends HandlerBase {
             port: this.upstreamProxyUrlParsed.port,
             path: targetHost,
             headers: {
-                host: targetHost,
+                Host: targetHost,
             },
         };
 


### PR DESCRIPTION
The handler_tunnel_chain.js file creates a CONNECT request to the real proxy and sets the desired target in the path parmater of the request options.
As far as I know the standard it to set it in the 'host' header...