### PR TITLE
Allow https scheme in upstream proxy url

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -299,8 +299,8 @@ export class Server extends EventEmitter {
                         if (!handlerOpts.upstreamProxyUrlParsed.hostname || !handlerOpts.upstreamProxyUrlParsed.port) {
                             throw new Error('Invalid "upstreamProxyUrl" provided: URL must have hostname and port');
                         }
-                        if (handlerOpts.upstreamProxyUrlParsed.scheme !== 'http') {
-                            throw new Error('Invalid "upstreamProxyUrl" provided: URL must have the "http" scheme');
+                        if (!['http', 'https'].includes(handlerOpts.upstreamProxyUrlParsed.scheme)) {
+                            throw new Error('Invalid "upstreamProxyUrl" provided: URL must have the "http" or "https" scheme');
                         }
                     }
                 }


### PR DESCRIPTION
At the moment, when you return an `upsteramProxyUrl` with `https` scheme in `prepareRequestFunction`  you get an error: `Request failed with unknown error: Error: Invalid "upstreamProxyUrl" provided: URL must have the "http" scheme`

It's a shame that it only shows the error in verbose mode as it's pretty critical. Took me 30 minutes to figure it out because I was simply seeing `net::ERR_TUNNEL_CONNECTION_FAILED` in puppeteer.

Is there a reason for only checking `http`?
Also, let me know if the use of `Array.includes` is acceptable.